### PR TITLE
Extract fallback template and clean imports

### DIFF
--- a/frontend/fallback.html
+++ b/frontend/fallback.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FullStock AI vNext Ultimate - MASTER BUILD VALIDATED</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>body { background: #1a1a1a; color: #fff; }</style>
+</head>
+<body>
+    <div class="container py-5">
+        <div class="text-center">
+            <h1 class="text-success mb-4">✅ MASTER BUILD VALIDATION COMPLETE</h1>
+            <div class="card bg-dark border-success">
+                <div class="card-body">
+                    <h5 class="text-primary">FullStock AI vNext Ultimate</h5>
+                    <p class="mb-3">Advanced Stock Prediction Platform - API Operational</p>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="card bg-secondary mb-3">
+                                <div class="card-body">
+                                    <h6>Real Data API Test</h6>
+                                    <button class="btn btn-primary" onclick="testAPI()">Test SPY Prediction</button>
+                                    <div id="apiResult" class="mt-2"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="card bg-secondary mb-3">
+                                <div class="card-body">
+                                    <h6>Validation Status</h6>
+                                    <p class="text-success">✅ Yahoo Finance Integration</p>
+                                    <p class="text-success">✅ Random Forest + XGBoost Models</p>
+                                    <p class="text-success">✅ Real Market Data (249-363 samples)</p>
+                                    <p class="text-success">✅ API Endpoints Operational</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-12">
+                            <div class="card bg-secondary">
+                                <div class="card-body">
+                                    <h6>Live API Examples</h6>
+                                    <div class="btn-group" role="group">
+                                        <button class="btn btn-outline-primary" onclick="testCrypto()">BTC-USD</button>
+                                        <button class="btn btn-outline-success" onclick="testStock('AAPL')">AAPL</button>
+                                        <button class="btn btn-outline-warning" onclick="testStock('MSFT')">MSFT</button>
+                                    </div>
+                                    <div id="liveResults" class="mt-3"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script>
+        async function testAPI() {
+            document.getElementById('apiResult').innerHTML = '<div class="text-info">Testing SPY prediction...</div>';
+            try {
+                const response = await fetch('/api/predict/SPY');
+                const data = await response.json();
+                if (data.error) {
+                    document.getElementById('apiResult').innerHTML =
+                        `<div class="text-warning">API Error: ${data.error}</div>`;
+                } else {
+                    document.getElementById('apiResult').innerHTML =
+                        `<div class="text-success">
+                            <strong>✅ API Working!</strong><br>
+                            Current: $${data.current_price.toFixed(2)}<br>
+                            Prediction: $${data.predictions.ensemble.prediction.toFixed(2)}<br>
+                            Agreement: ${(data.agreement_level * 100).toFixed(1)}%
+                        </div>`;
+                }
+            } catch (error) {
+                document.getElementById('apiResult').innerHTML =
+                    `<div class="text-danger">Connection Error: ${error.message}</div>`;
+            }
+        }
+
+        async function testCrypto() {
+            document.getElementById('liveResults').innerHTML = '<div class="text-info">Testing BTC-USD...</div>';
+            try {
+                const response = await fetch('/api/predict/BTC-USD');
+                const data = await response.json();
+                document.getElementById('liveResults').innerHTML =
+                    `<div class="text-success">
+                        <strong>BTC-USD:</strong> $${data.current_price.toFixed(2)}
+                        → $${data.predictions.ensemble.prediction.toFixed(2)}
+                    </div>`;
+            } catch (error) {
+                document.getElementById('liveResults').innerHTML =
+                    `<div class="text-warning">Error: ${error.message}</div>`;
+            }
+        }
+
+        async function testStock(ticker) {
+            document.getElementById('liveResults').innerHTML = `<div class="text-info">Testing ${ticker}...</div>`;
+            try {
+                const response = await fetch(`/api/predict/${ticker}`);
+                const data = await response.json();
+                document.getElementById('liveResults').innerHTML =
+                    `<div class="text-success">
+                        <strong>${ticker}:</strong> $${data.current_price.toFixed(2)}
+                        → $${data.predictions.ensemble.prediction.toFixed(2)}
+                    </div>`;
+            } catch (error) {
+                document.getElementById('liveResults').innerHTML =
+                    `<div class="text-warning">Error: ${error.message}</div>`;
+            }
+        }
+    </script>
+</body>
+</html>
+

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -1,6 +1,4 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash, session
-from flask_socketio import emit
-import os
+from flask import Blueprint, render_template
 
 main_bp = Blueprint('main', __name__)
 
@@ -9,126 +7,9 @@ def index():
     """Main dashboard with comprehensive stock prediction interface"""
     try:
         return render_template('index.html')
-    except Exception as e:
+    except Exception:
         # Fallback validation interface for MASTER BUILD
-        return f'''
-        <!DOCTYPE html>
-        <html lang="en">
-        <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>FullStock AI vNext Ultimate - MASTER BUILD VALIDATED</title>
-            <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-            <style>body {{ background: #1a1a1a; color: #fff; }}</style>
-        </head>
-        <body>
-            <div class="container py-5">
-                <div class="text-center">
-                    <h1 class="text-success mb-4">✅ MASTER BUILD VALIDATION COMPLETE</h1>
-                    <div class="card bg-dark border-success">
-                        <div class="card-body">
-                            <h5 class="text-primary">FullStock AI vNext Ultimate</h5>
-                            <p class="mb-3">Advanced Stock Prediction Platform - API Operational</p>
-                            <div class="row">
-                                <div class="col-md-6">
-                                    <div class="card bg-secondary mb-3">
-                                        <div class="card-body">
-                                            <h6>Real Data API Test</h6>
-                                            <button class="btn btn-primary" onclick="testAPI()">Test SPY Prediction</button>
-                                            <div id="apiResult" class="mt-2"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-md-6">
-                                    <div class="card bg-secondary mb-3">
-                                        <div class="card-body">
-                                            <h6>Validation Status</h6>
-                                            <p class="text-success">✅ Yahoo Finance Integration</p>
-                                            <p class="text-success">✅ Random Forest + XGBoost Models</p>
-                                            <p class="text-success">✅ Real Market Data (249-363 samples)</p>
-                                            <p class="text-success">✅ API Endpoints Operational</p>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <div class="col-12">
-                                    <div class="card bg-secondary">
-                                        <div class="card-body">
-                                            <h6>Live API Examples</h6>
-                                            <div class="btn-group" role="group">
-                                                <button class="btn btn-outline-primary" onclick="testCrypto()">BTC-USD</button>
-                                                <button class="btn btn-outline-success" onclick="testStock('AAPL')">AAPL</button>
-                                                <button class="btn btn-outline-warning" onclick="testStock('MSFT')">MSFT</button>
-                                            </div>
-                                            <div id="liveResults" class="mt-3"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <script>
-                async function testAPI() {{
-                    document.getElementById('apiResult').innerHTML = '<div class="text-info">Testing SPY prediction...</div>';
-                    try {{
-                        const response = await fetch('/api/predict/SPY');
-                        const data = await response.json();
-                        if (data.error) {{
-                            document.getElementById('apiResult').innerHTML = 
-                                `<div class="text-warning">API Error: ${{data.error}}</div>`;
-                        }} else {{
-                            document.getElementById('apiResult').innerHTML = 
-                                `<div class="text-success">
-                                    <strong>✅ API Working!</strong><br>
-                                    Current: $$${{data.current_price.toFixed(2)}}<br>
-                                    Prediction: $$${{data.predictions.ensemble.prediction.toFixed(2)}}<br>
-                                    Agreement: ${{(data.agreement_level * 100).toFixed(1)}}%
-                                </div>`;
-                        }}
-                    }} catch (error) {{
-                        document.getElementById('apiResult').innerHTML = 
-                            `<div class="text-danger">Connection Error: ${{error.message}}</div>`;
-                    }}
-                }}
-                
-                async function testCrypto() {{
-                    document.getElementById('liveResults').innerHTML = '<div class="text-info">Testing BTC-USD...</div>';
-                    try {{
-                        const response = await fetch('/api/predict/BTC-USD');
-                        const data = await response.json();
-                        document.getElementById('liveResults').innerHTML = 
-                            `<div class="text-success">
-                                <strong>BTC-USD:</strong> $$${{data.current_price.toFixed(2)}} 
-                                → $$${{data.predictions.ensemble.prediction.toFixed(2)}}
-                            </div>`;
-                    }} catch (error) {{
-                        document.getElementById('liveResults').innerHTML = 
-                            `<div class="text-warning">Error: ${{error.message}}</div>`;
-                    }}
-                }}
-                
-                async function testStock(ticker) {{
-                    document.getElementById('liveResults').innerHTML = `<div class="text-info">Testing ${{ticker}}...</div>`;
-                    try {{
-                        const response = await fetch(`/api/predict/${{ticker}}`);
-                        const data = await response.json();
-                        document.getElementById('liveResults').innerHTML = 
-                            `<div class="text-success">
-                                <strong>${{ticker}}:</strong> $$${{data.current_price.toFixed(2)}} 
-                                → $$${{data.predictions.ensemble.prediction.toFixed(2)}}
-                            </div>`;
-                    }} catch (error) {{
-                        document.getElementById('liveResults').innerHTML = 
-                            `<div class="text-warning">Error: ${{error.message}}</div>`;
-                    }}
-                }}
-            </script>
-        </body>
-        </html>
-        '''
+        return render_template('fallback.html')
 
 @main_bp.route('/crypto')
 def crypto():


### PR DESCRIPTION
## Summary
- Serve fallback page from new `fallback.html` template instead of inline HTML.
- Remove unused Flask and OS imports from `main.py`.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d6ae3478832a9f6a68de25931d4f