### PR TITLE
feat: add toast notifications

### DIFF
--- a/frontend/crypto.html
+++ b/frontend/crypto.html
@@ -289,6 +289,8 @@
         </div>
     </div>
 
+    <div id="toastContainer" class="toast-container"></div>
+
     <!-- Loading Overlay -->
     <div id="loadingOverlay" class="position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.8); z-index: 9999; display: none;">
         <div class="text-center">
@@ -304,6 +306,7 @@
     <!-- Application Scripts -->
     <script src="/static/js/sockets.js"></script>
     <script src="/static/js/charts.js"></script>
+    <script src="/static/js/notifications.js"></script>
     <script src="/static/js/crypto.js"></script>
     
     <script>

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -423,3 +423,40 @@ body {
   justify-content: center;
   z-index: 1050;
 }
+
+/* Toast Notifications */
+.toast-container {
+  position: fixed;
+  top: var(--fs-spacing-md);
+  right: var(--fs-spacing-md);
+  z-index: var(--fs-z-toast);
+}
+
+.toast {
+  background: var(--card-bg);
+  color: var(--fs-color-text);
+  padding: var(--fs-spacing-sm) var(--fs-spacing-md);
+  margin-bottom: var(--fs-spacing-sm);
+  border-radius: var(--fs-radius-md);
+  box-shadow: var(--fs-shadow-md);
+  opacity: 0;
+  transform: translateX(100%);
+  transition: var(--fs-transition-base);
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.toast-success {
+  border-left: 4px solid var(--fs-color-success);
+}
+
+.toast-error {
+  border-left: 4px solid var(--fs-color-danger);
+}
+
+.toast-info {
+  border-left: 4px solid var(--fs-color-primary);
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -294,12 +294,15 @@
         </div>
     </div>
 
+    <div id="toastContainer" class="toast-container"></div>
+
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    
+
     <!-- Application Scripts -->
     <script src="/static/js/sockets.js"></script>
     <script src="/static/js/charts.js"></script>
+    <script src="/static/js/notifications.js"></script>
     <script src="/static/js/dashboard.js"></script>
     
     <script>

--- a/frontend/js/crypto.js
+++ b/frontend/js/crypto.js
@@ -483,8 +483,7 @@ function hideCryptoLoadingState() {
 }
 
 function showCryptoError(message) {
-    console.error('Crypto error:', message);
-    // Could implement toast notification
+    createToast(message, 'error');
 }
 
 /**

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -368,8 +368,7 @@ function hideLoadingState() {
  * Show Error Message
  */
 function showError(message) {
-    // You could implement a toast notification system here
-    console.error(message);
+    createToast(message, 'error');
 }
 
 /**

--- a/frontend/js/notifications.js
+++ b/frontend/js/notifications.js
@@ -1,0 +1,32 @@
+/**
+ * Utility for displaying toast notifications.
+ * @param {string} message - Message to display.
+ * @param {'success'|'error'|'info'} [type='info'] - Type of toast.
+ */
+function createToast(message, type = 'info') {
+    const container = document.getElementById('toastContainer');
+    if (!container) {
+        console.error('Toast container not found');
+        return;
+    }
+
+    const toast = document.createElement('div');
+    toast.className = `toast toast-${type}`;
+    toast.textContent = message;
+    container.appendChild(toast);
+
+    // Trigger show transition
+    requestAnimationFrame(() => {
+        toast.classList.add('show');
+    });
+
+    // Auto-remove after 5 seconds
+    setTimeout(() => {
+        toast.classList.remove('show');
+        toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+    }, 5000);
+}
+
+window.createToast = createToast;
+window.showNotification = createToast;
+

--- a/frontend/js/oracle.js
+++ b/frontend/js/oracle.js
@@ -444,8 +444,8 @@ function hideOracleLoadingState() {
 }
 
 function showOracleError(message) {
-    console.error('Oracle error:', message);
-    
+    createToast(message, 'error');
+
     // Update main oracle panel with error message
     document.getElementById('oracleSymbol').textContent = '🌫️';
     document.getElementById('oracleTitle').textContent = 'Oracle Vision Clouded';

--- a/frontend/js/portfolio.js
+++ b/frontend/js/portfolio.js
@@ -596,8 +596,7 @@ function hidePortfolioLoadingState() {
 }
 
 function showPortfolioError(message) {
-    console.error('Portfolio error:', message);
-    // Could implement toast notification
+    createToast(message, 'error');
 }
 
 /**

--- a/frontend/oracle.html
+++ b/frontend/oracle.html
@@ -281,6 +281,8 @@
         </div>
     </div>
 
+    <div id="toastContainer" class="toast-container"></div>
+
     <!-- Loading Overlay -->
     <div id="oracleLoadingOverlay" class="position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.8); z-index: 9999; display: none;">
         <div class="text-center">
@@ -295,6 +297,7 @@
     
     <!-- Application Scripts -->
     <script src="{{ url_for('static', filename='js/sockets.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/notifications.js') }}"></script>
     <script src="{{ url_for('static', filename='js/oracle.js') }}"></script>
     
     <script>

--- a/frontend/portfolio.html
+++ b/frontend/portfolio.html
@@ -316,6 +316,8 @@
         </div>
     </div>
 
+    <div id="toastContainer" class="toast-container"></div>
+
     <!-- Loading Overlay -->
     <div id="portfolioLoadingOverlay" class="position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.8); z-index: 9999; display: none;">
         <div class="text-center">
@@ -330,6 +332,7 @@
     
     <!-- Application Scripts -->
     <script src="{{ url_for('static', filename='js/sockets.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/notifications.js') }}"></script>
     <script src="{{ url_for('static', filename='js/portfolio.js') }}"></script>
     
     <script>


### PR DESCRIPTION
## Summary
- add shared toast container and include notification script on key pages
- style toast messages and add `createToast` utility for notifications
- route error handlers through `createToast` across dashboard, crypto, oracle, and portfolio scripts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898de5769e8832ab801f2fd0545531f