### PR TITLE
Add analyze spinner and loading state controls

### DIFF
--- a/frontend/crypto.html
+++ b/frontend/crypto.html
@@ -96,6 +96,7 @@
                                            value="BTC-USD"
                                            autocomplete="off">
                                     <button class="btn btn-primary" type="button" id="analyzeCryptoBtn">
+                                        <span id="analyzeSpinner" class="loading-spinner me-2" style="display:none"></span>
                                         <i data-feather="zap" class="me-1"></i>
                                         <span id="analyzeText">Analyze</span>
                                     </button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -97,6 +97,7 @@
                                            value="SPY"
                                            autocomplete="off">
                                     <button class="btn btn-primary" type="button" id="analyzeBtn">
+                                        <span id="analyzeSpinner" class="loading-spinner me-2" style="display:none"></span>
                                         <i data-feather="zap" class="me-1"></i>
                                         <span id="analyzeText">Analyze</span>
                                     </button>

--- a/frontend/js/crypto.js
+++ b/frontend/js/crypto.js
@@ -12,7 +12,11 @@ let isAnalyzingCrypto = false;
  */
 function initializeCryptoDashboard() {
     console.log('Crypto Dashboard initialized');
-    
+
+    // Ensure analyze spinner is hidden initially
+    const analyzeSpinner = document.getElementById('analyzeSpinner');
+    if (analyzeSpinner) analyzeSpinner.style.display = 'none';
+
     // Setup event listeners
     setupCryptoEventListeners();
     
@@ -465,20 +469,24 @@ function showCryptoResultSections() {
 function showCryptoLoadingState() {
     const analyzeBtn = document.getElementById('analyzeCryptoBtn');
     const analyzeText = document.getElementById('analyzeText');
+    const analyzeSpinner = document.getElementById('analyzeSpinner');
     const loadingOverlay = document.getElementById('loadingOverlay');
-    
+
     if (analyzeBtn) analyzeBtn.disabled = true;
     if (analyzeText) analyzeText.textContent = 'Analyzing...';
+    if (analyzeSpinner) analyzeSpinner.style.display = 'inline-block';
     if (loadingOverlay) loadingOverlay.style.display = 'flex';
 }
 
 function hideCryptoLoadingState() {
     const analyzeBtn = document.getElementById('analyzeCryptoBtn');
     const analyzeText = document.getElementById('analyzeText');
+    const analyzeSpinner = document.getElementById('analyzeSpinner');
     const loadingOverlay = document.getElementById('loadingOverlay');
-    
+
     if (analyzeBtn) analyzeBtn.disabled = false;
     if (analyzeText) analyzeText.textContent = 'Analyze';
+    if (analyzeSpinner) analyzeSpinner.style.display = 'none';
     if (loadingOverlay) loadingOverlay.style.display = 'none';
 }
 

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -54,8 +54,10 @@ function forceHideLoading() {
     // Reset analyze button
     const analyzeBtn = document.getElementById('analyzeBtn');
     const analyzeText = document.getElementById('analyzeText');
+    const analyzeSpinner = document.getElementById('analyzeSpinner');
     if (analyzeBtn) analyzeBtn.disabled = false;
     if (analyzeText) analyzeText.textContent = 'Analyze';
+    if (analyzeSpinner) analyzeSpinner.style.display = 'none';
     
     // Reset analyzing flag
     isAnalyzing = false;
@@ -300,6 +302,7 @@ function showLoadingState() {
     console.log('Showing loading state...');
     const analyzeBtn = document.getElementById('analyzeBtn');
     const analyzeText = document.getElementById('analyzeText');
+    const analyzeSpinner = document.getElementById('analyzeSpinner');
     const loadingOverlay = document.getElementById('loadingOverlay');
     
     if (analyzeBtn) {
@@ -309,6 +312,10 @@ function showLoadingState() {
     if (analyzeText) {
         analyzeText.textContent = 'Analyzing...';
         console.log('Analyze text updated');
+    }
+    if (analyzeSpinner) {
+        analyzeSpinner.style.display = 'inline-block';
+        console.log('Analyze spinner shown');
     }
     if (loadingOverlay) {
         loadingOverlay.style.display = 'flex';
@@ -336,6 +343,7 @@ function hideLoadingState() {
     console.log('Hiding loading state...');
     const analyzeBtn = document.getElementById('analyzeBtn');
     const analyzeText = document.getElementById('analyzeText');
+    const analyzeSpinner = document.getElementById('analyzeSpinner');
     const loadingOverlay = document.getElementById('loadingOverlay');
     
     if (analyzeBtn) {
@@ -345,6 +353,10 @@ function hideLoadingState() {
     if (analyzeText) {
         analyzeText.textContent = 'Analyze';
         console.log('Analyze text reset');
+    }
+    if (analyzeSpinner) {
+        analyzeSpinner.style.display = 'none';
+        console.log('Analyze spinner hidden');
     }
     if (loadingOverlay) {
         loadingOverlay.style.display = 'none';


### PR DESCRIPTION
## Summary
- Add hidden loading spinner to analyze buttons in stock and crypto pages
- Toggle spinner visibility in dashboard and crypto scripts during analysis

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898de513ff8832ab69f48d45d88410a