### PR TITLE
Validate symbols and display inline input errors

### DIFF
--- a/frontend/js/crypto.js
+++ b/frontend/js/crypto.js
@@ -6,6 +6,7 @@
 let currentCrypto = 'BTC-USD';
 let cryptoChart = null;
 let isAnalyzingCrypto = false;
+const CRYPTO_PATTERN = /^[A-Z.-]{1,10}$/;
 
 /**
  * Initialize Crypto Dashboard
@@ -54,6 +55,10 @@ function setupCryptoEventListeners() {
                 }
             }
         });
+
+        cryptoInput.addEventListener('input', () => {
+            clearInputError();
+        });
     }
 
     // Quick crypto buttons
@@ -61,6 +66,7 @@ function setupCryptoEventListeners() {
         btn.addEventListener('click', () => {
             const crypto = btn.getAttribute('data-crypto');
             cryptoInput.value = crypto;
+            clearInputError();
             analyzeCrypto(crypto);
         });
     });
@@ -85,6 +91,13 @@ function setupCryptoEventListeners() {
  * Analyze Cryptocurrency - Main Function
  */
 async function analyzeCrypto(crypto) {
+    if (!CRYPTO_PATTERN.test(crypto)) {
+        displayInputError('Please enter a valid crypto symbol (1-10 uppercase letters, dots or hyphens).');
+        return;
+    }
+
+    clearInputError();
+
     if (isAnalyzingCrypto) return;
     
     console.log(`Analyzing crypto ${crypto}...`);
@@ -480,6 +493,25 @@ function hideCryptoLoadingState() {
     if (analyzeBtn) analyzeBtn.disabled = false;
     if (analyzeText) analyzeText.textContent = 'Analyze';
     if (loadingOverlay) loadingOverlay.style.display = 'none';
+}
+
+/**
+ * Input validation helpers
+ */
+function displayInputError(message) {
+    clearInputError();
+    const input = document.getElementById('cryptoInput');
+    if (!input) return;
+    const errorEl = document.createElement('div');
+    errorEl.id = 'cryptoError';
+    errorEl.className = 'text-danger mt-1';
+    errorEl.textContent = message;
+    input.parentElement.insertAdjacentElement('afterend', errorEl);
+}
+
+function clearInputError() {
+    const errorEl = document.getElementById('cryptoError');
+    if (errorEl) errorEl.remove();
 }
 
 function showCryptoError(message) {

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -5,6 +5,7 @@
 
 let currentTicker = 'SPY';
 let isAnalyzing = false;
+const TICKER_PATTERN = /^[A-Z.-]{1,10}$/;
 
 /**
  * Initialize Dashboard
@@ -90,11 +91,17 @@ function setupEventListeners() {
         }
     });
 
+    // Clear error on input change
+    tickerInput.addEventListener('input', () => {
+        clearInputError();
+    });
+
     // Quick ticker buttons
     quickTickers.forEach(btn => {
         btn.addEventListener('click', () => {
             const ticker = btn.getAttribute('data-ticker');
             tickerInput.value = ticker;
+            clearInputError();
             analyzeStock(ticker);
         });
     });
@@ -139,6 +146,13 @@ function setupScrollTopButton() {
  * Analyze Stock - Main Function
  */
 async function analyzeStock(ticker) {
+    if (!TICKER_PATTERN.test(ticker)) {
+        displayInputError('Please enter a valid stock symbol (1-10 uppercase letters, dots or hyphens).');
+        return;
+    }
+
+    clearInputError();
+
     if (isAnalyzing) return;
     
     console.log(`Analyzing ${ticker}...`);
@@ -362,6 +376,25 @@ function hideLoadingState() {
     isAnalyzing = false;
     
     console.log('Loading state hidden successfully');
+}
+
+/**
+ * Input validation helpers
+ */
+function displayInputError(message) {
+    clearInputError();
+    const input = document.getElementById('tickerInput');
+    if (!input) return;
+    const errorEl = document.createElement('div');
+    errorEl.id = 'tickerError';
+    errorEl.className = 'text-danger mt-1';
+    errorEl.textContent = message;
+    input.parentElement.insertAdjacentElement('afterend', errorEl);
+}
+
+function clearInputError() {
+    const errorEl = document.getElementById('tickerError');
+    if (errorEl) errorEl.remove();
 }
 
 /**


### PR DESCRIPTION
## Summary
- add regex-based ticker validation with inline warnings and clear-on-edit logic in stock dashboard
- mirror validation and messaging for crypto symbols

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898de59fd70832a80360a778de5c952