### PR TITLE
refactor: remove unused json import

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import json
 from datetime import datetime
 from flask import Flask, jsonify
 from flask_sqlalchemy import SQLAlchemy
@@ -127,6 +126,8 @@ def quotes(ws):
         'prediction': 'hold',
         'timestamp': datetime.utcnow().isoformat()
     }
+    import json
+
     ws.send(json.dumps(initial_data))
     while True:
         message = ws.receive()


### PR DESCRIPTION
## Summary
- remove unused json import and localize usage in websocket route to satisfy lint

## Testing
- `ruff check app.py server/api server/config.py server/utils/logging.py`
- `pytest -q` *(fails: cannot import name 'app' from 'app')*


------
https://chatgpt.com/codex/tasks/task_e_6898e94887bc832a95c9679771988ac0