### PR TITLE
fix: stabilize websocket connection and loading states

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,21 +1,21 @@
-# Gunicorn configuration for Flask-SocketIO with WebSocket support
+# Gunicorn configuration for Flask-Sock with gevent WebSocket support
 import multiprocessing
 
 # Server socket
 bind = "0.0.0.0:5000"
 backlog = 512
 
-# Worker processes optimized for Flask-SocketIO
-workers = 1  # Single worker required for SocketIO
-worker_class = "eventlet"  # Required for WebSocket support
+# Worker processes optimized for WebSocket
+workers = 1
+worker_class = "gevent"
 worker_connections = 1000
-timeout = 120  # Extended timeout for WebSocket connections
+timeout = 120
 keepalive = 5
 
-# Restart workers - adjusted for SocketIO stability
-max_requests = 0  # Disable auto-restart for WebSocket stability
+# Restart workers - adjusted for WebSocket stability
+max_requests = 0
 max_requests_jitter = 0
-preload_app = False  # Disable preloading for SocketIO compatibility
+preload_app = False
 
 # Logging
 loglevel = "info"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "vadersentiment==3.3.2",
     "psutil==7.0.0",
     "backend==0.2.4.1",
+    "gevent==24.2.1",
+    "gevent-websocket==0.10.1",
     "eventlet==0.40.2",
 ]
 

--- a/start_server.py
+++ b/start_server.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 """
 FullStock AI Server Startup Script
-Ensures proper WebSocket support with eventlet
+Ensures proper WebSocket support with gevent
 """
 
 from app import app, socketio
 
 if __name__ == '__main__':
-    # Start with eventlet support for WebSockets
     print("🚀 Starting FullStock AI with WebSocket support...")
     socketio.run(
-        app, 
-        host='0.0.0.0', 
-        port=5000, 
-        debug=True, 
-        use_reloader=False, 
+        app,
+        host='0.0.0.0',
+        port=5000,
+        debug=True,
+        use_reloader=False,
         log_output=True
     )
+


### PR DESCRIPTION
## Summary
- rebuild client WebSocket URL from page origin and add verbose lifecycle logging with exponential backoff reconnect
- serve `/ws/quotes` via Flask‑Sock streaming JSON ticker updates
- configure gevent-based runners and add minimal WebSocket smoke test

## Testing
- `pytest tests/test_ws.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898ecf06bc0832a9d93791f293de664