### PR TITLE
Fix invalid SocketIO async_mode for Gunicorn startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,8 +55,8 @@ app.config["MAIL_PASSWORD"] = os.environ.get("MAIL_PASSWORD")
 
 # Initialize extensions
 db.init_app(app)
-# Initialize SocketIO with gevent for WebSocket support
-socketio.init_app(app, cors_allowed_origins="*", async_mode='gevent', logger=True, engineio_logger=True)
+# Initialize SocketIO with a portable threading async mode
+socketio.init_app(app, cors_allowed_origins="*", async_mode='threading', logger=True, engineio_logger=True)
 cache.init_app(app)
 mail.init_app(app)
 sock.init_app(app)


### PR DESCRIPTION
## Summary
- Replace hard-coded gevent async_mode with portable threading mode for Flask-SocketIO
- Keeps SocketIO initialization compatible when gevent isn't installed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898f3628900832abc3f17a6a3de7035