### PR TITLE
fix: add fallback colors for gradient text

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -68,6 +68,8 @@ body {
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  /* Fallback color for browsers without text-clip support */
+  color: var(--fs-color-primary);
 }
 
 /* Button Enhancements */
@@ -127,6 +129,8 @@ body {
   -webkit-text-fill-color: transparent;
   background-clip: text;
   text-align: center;
+  /* Fallback color to maintain readability */
+  color: var(--fs-color-success);
 }
 
 .prediction-card {
@@ -365,6 +369,8 @@ body {
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  /* Ensure visible text when gradients are unsupported */
+  color: var(--fs-color-primary);
 }
 
 .glass-effect {


### PR DESCRIPTION
## Summary
- add explicit text colors to gradient-styled elements like navbar brand, live price, and utility class

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas', ModuleNotFoundError: No module named 'eventlet')*

------
https://chatgpt.com/codex/tasks/task_e_6898f3a57a90832aa25e10bda4f22c5c