### PR TITLE
Use non-blocking sleep in websocket handler

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 import os
 import logging
 import json
-import time
 from datetime import datetime
 from flask import Flask, jsonify
 from flask_sqlalchemy import SQLAlchemy
@@ -128,6 +127,6 @@ def quotes(ws):
             'timestamp': datetime.utcnow().isoformat()
         }
         ws.send(json.dumps(data))
-        time.sleep(1)
+        socketio.sleep(1)
 
 # Routes are handled by server/api blueprints


### PR DESCRIPTION
## Summary
- avoid blocking gunicorn workers in `/ws/quotes` by yielding with `socketio.sleep`

## Testing
- `pytest tests/test_ws.py::test_ws_quotes -q`
- `pytest tests/test_prediction_routes.py::test_http_and_ws_prediction_consistency -q`


------
https://chatgpt.com/codex/tasks/task_e_6898f738486c832a9e1b5f3cccc0c40f