### PR TITLE
fix: include websocket client dependency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ FLASK_DEBUG=False
 DATABASE_URL=sqlite:///fullstock.db
 MAIL_SERVER=smtp.gmail.com
 MAIL_PORT=587
+MAIL_USE_TLS=True
 MAIL_USERNAME=example@gmail.com
 MAIL_PASSWORD=password123
 MAIL_DEFAULT_SENDER=example@gmail.com
@@ -18,3 +19,4 @@ RATELIMIT_ENABLED=True
 RATELIMIT_DEFAULT='100 per hour'
 SESSION_SECRET=fallback-secret-key-for-development
 HTTPS=False
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "gevent==24.2.1",
     "gevent-websocket==0.10.1",
     "eventlet==0.40.2",
+    "websocket-client==1.8.0",
 ]
 
 [build-system]
@@ -51,5 +52,4 @@ dev = [
     "pytest==8.4.1",
     "ruff==0.12.7",
     "pyright==1.1.403",
-    "websocket-client==1.8.0",
 ]


### PR DESCRIPTION
## Summary
- add `websocket-client` to application dependencies
- document TLS flag in env example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898fcfcd88c832aa66c749aa1a1bdf8