### PR TITLE
refactor: use timezone aware datetimes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,5 @@ RATELIMIT_ENABLED=True
 RATELIMIT_DEFAULT='100 per hour'
 SESSION_SECRET=fallback-secret-key-for-development
 HTTPS=False
+TZ=UTC
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# FullStockAI
+
+FullStockAI is an experimental stock analysis and prediction platform built with Flask and various machine learning services.
+
+## Development
+
+```bash
+pip install -e .
+pytest
+```
+
+The application uses timezone-aware datetimes. Ensure the environment variable `TZ=UTC` (see `.env.example`).
+
+## Running
+
+```bash
+python app.py
+```
+
+## Tests
+
+Run all tests with `pytest`.
+

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import os
 import logging
 import json
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from flask import Flask, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from flask_socketio import SocketIO
@@ -125,7 +125,7 @@ def quotes(ws):
     while True:
         data = {
             'ticker': 'SPY',
-            'timestamp': datetime.utcnow().isoformat()
+            'timestamp': datetime.now(timezone.utc).isoformat()
         }
         ws.send(json.dumps(data))
         time.sleep(1)

--- a/models.py
+++ b/models.py
@@ -1,6 +1,6 @@
 from app import db
 from flask_login import UserMixin
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 
 class User(UserMixin, db.Model):
@@ -12,7 +12,7 @@ class User(UserMixin, db.Model):
 class StockPrediction(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     ticker = db.Column(db.String(10), nullable=False)
-    prediction_date = db.Column(db.DateTime, default=datetime.utcnow)
+    prediction_date = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     current_price = db.Column(db.Float, nullable=False)
     predicted_price = db.Column(db.Float, nullable=False)
     confidence = db.Column(db.Float, nullable=False)
@@ -25,13 +25,13 @@ class PriceAlert(db.Model):
     target_price = db.Column(db.Float, nullable=False)
     alert_type = db.Column(db.String(10), nullable=False)  # 'above' or 'below'
     is_active = db.Column(db.Boolean, default=True)
-    created_date = db.Column(db.DateTime, default=datetime.utcnow)
+    created_date = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     triggered_date = db.Column(db.DateTime)
     user_email = db.Column(db.String(120))
 
 class SystemHealth(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    timestamp = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     component = db.Column(db.String(50), nullable=False)
     status = db.Column(db.String(20), nullable=False)  # 'healthy', 'warning', 'error'
     metrics = db.Column(db.Text)  # JSON string of health metrics
@@ -40,7 +40,7 @@ class SystemHealth(db.Model):
 class ModelPerformance(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     model_name = db.Column(db.String(30), nullable=False)
-    evaluation_date = db.Column(db.DateTime, default=datetime.utcnow)
+    evaluation_date = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     accuracy_score = db.Column(db.Float)
     mse_score = db.Column(db.Float)
     mae_score = db.Column(db.Float)
@@ -51,7 +51,7 @@ class ModelPerformance(db.Model):
 
 class TradingSession(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    session_date = db.Column(db.DateTime, default=datetime.utcnow)
+    session_date = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     ticker = db.Column(db.String(10), nullable=False)
     strategy = db.Column(db.String(50), nullable=False)
     entry_price = db.Column(db.Float, nullable=False)

--- a/server/api/api.py
+++ b/server/api/api.py
@@ -12,7 +12,7 @@ from server.utils.strategic.curiosity_engine import CuriosityEngine
 from server.utils.strategic.health_monitor import HealthMonitor
 from server.utils.services.portfolio_manager import PortfolioManager
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 api_bp = Blueprint('api', __name__)
 
@@ -92,7 +92,7 @@ def _generate_prediction(ticker, data=None):
         'current_price': current_price,
         'predictions': predictions,
         'agreement_level': agreement_level,
-        'timestamp': datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S+00:00"),
+        'timestamp': datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S%z"),
     }
 
     return response_data
@@ -241,7 +241,7 @@ def health_check():
         
         health_status = {
             'status': 'healthy',
-            'timestamp': datetime.utcnow().isoformat(),
+            'timestamp': datetime.now(timezone.utc).isoformat(),
             'services': {
                 'data_fetcher': data_status,
                 'ml_manager': 'healthy',
@@ -259,7 +259,7 @@ def health_check():
         return jsonify({
             'status': 'unhealthy',
             'error': str(e),
-            'timestamp': datetime.utcnow().isoformat()
+            'timestamp': datetime.now(timezone.utc).isoformat()
         }), 500
 
 # WebSocket event handlers
@@ -267,7 +267,7 @@ def health_check():
 def handle_connect():
     """Handle WebSocket connection"""
     logging.info('Client connected to WebSocket')
-    emit('connected', {'status': 'Connected to FullStock AI', 'timestamp': datetime.utcnow().isoformat()})
+    emit('connected', {'status': 'Connected to FullStock AI', 'timestamp': datetime.now(timezone.utc).isoformat()})
 
 @socketio.on('disconnect') 
 def handle_disconnect():
@@ -288,7 +288,7 @@ def handle_subscribe_ticker(data):
             emit('price_update', {
                 'ticker': ticker,
                 'price': current_price,
-                'timestamp': datetime.utcnow().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             })
     except Exception as e:
         logging.error(f"Subscribe ticker error: {str(e)}")
@@ -337,7 +337,7 @@ def handle_live_data_request(data):
             emit('live_price_update', {
                 'ticker': ticker,
                 'price': current_price,
-                'timestamp': datetime.utcnow().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             })
     except Exception as e:
         logging.error(f"Live data request error: {str(e)}")
@@ -356,7 +356,7 @@ def get_sentiment(symbol):
         return jsonify({
             'symbol': symbol,
             'sentiment': sentiment_data,
-            'timestamp': datetime.utcnow().isoformat()
+            'timestamp': datetime.now(timezone.utc).isoformat()
         })
     except Exception as e:
         logging.error(f"Sentiment analysis error: {str(e)}")
@@ -372,7 +372,7 @@ def get_oracle_vision(symbol):
         return jsonify({
             'symbol': symbol,
             'vision': vision_data,
-            'timestamp': datetime.utcnow().isoformat()
+            'timestamp': datetime.now(timezone.utc).isoformat()
         })
     except Exception as e:
         logging.error(f"Oracle vision error: {str(e)}")
@@ -386,7 +386,7 @@ def get_oracle_dreams():
         dreams_data = oracle_service.generate_insight('MARKET')
         return jsonify({
             'dreams': dreams_data,
-            'timestamp': datetime.utcnow().isoformat()
+            'timestamp': datetime.now(timezone.utc).isoformat()
         })
     except Exception as e:
         logging.error(f"Oracle dreams error: {str(e)}")
@@ -403,7 +403,7 @@ def get_portfolio_analysis(symbol):
         return jsonify({
             'symbol': symbol,
             'portfolio_analysis': portfolio_data,
-            'timestamp': datetime.utcnow().isoformat()
+            'timestamp': datetime.now(timezone.utc).isoformat()
         })
     except Exception as e:
         logging.error(f"Portfolio analysis error: {str(e)}")
@@ -417,7 +417,7 @@ def get_model_status():
         status_data = health_monitor.get_health_status()
         return jsonify({
             'model_status': status_data,
-            'timestamp': datetime.utcnow().isoformat()
+            'timestamp': datetime.now(timezone.utc).isoformat()
         })
     except Exception as e:
         logging.error(f"Model status error: {str(e)}")
@@ -433,7 +433,7 @@ def get_curiosity_analysis(symbol):
         return jsonify({
             'symbol': symbol,
             'curiosity_analysis': curiosity_data,
-            'timestamp': datetime.utcnow().isoformat()
+            'timestamp': datetime.now(timezone.utc).isoformat()
         })
     except Exception as e:
         logging.error(f"Curiosity analysis error: {str(e)}")

--- a/server/ml/cache_manager.py
+++ b/server/ml/cache_manager.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from typing import Any, Dict, Optional, Union
 from app import cache
 import pickle
@@ -74,9 +74,9 @@ class CacheManager:
             # Wrap value with metadata
             cache_entry = {
                 'value': value,
-                'cached_at': datetime.utcnow().isoformat(),
+                'cached_at': datetime.now(timezone.utc).isoformat(),
                 'ttl': ttl,
-                'expires_at': (datetime.utcnow() + timedelta(seconds=ttl)).isoformat()
+                'expires_at': (datetime.now(timezone.utc) + timedelta(seconds=ttl)).isoformat()
             }
             
             cache.set(key, cache_entry, timeout=ttl)
@@ -261,14 +261,14 @@ class CacheManager:
                 'deletes': self.cache_stats['deletes'],
                 'total_requests': total_requests,
                 'hit_rate_percent': round(hit_rate, 2),
-                'timestamp': datetime.utcnow().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             }
             
         except Exception as e:
             self.logger.error(f"Error getting cache stats: {str(e)}")
             return {
                 'error': str(e),
-                'timestamp': datetime.utcnow().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             }
     
     def warm_cache(self, symbols: list) -> Dict:
@@ -314,7 +314,7 @@ class CacheManager:
                 'symbols_processed': len(symbols),
                 'successful': warmed_count,
                 'failed': failed_count,
-                'timestamp': datetime.utcnow().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             }
             
             self.logger.info(f"Cache warm-up completed: {warmed_count} successful, {failed_count} failed")
@@ -327,7 +327,7 @@ class CacheManager:
                 'symbols_processed': 0,
                 'successful': 0,
                 'failed': len(symbols) if symbols else 0,
-                'timestamp': datetime.utcnow().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             }
     
     def set_with_tags(self, key: str, value: Any, tags: list, ttl: Optional[int] = None) -> bool:
@@ -350,7 +350,7 @@ class CacheManager:
             cache_entry = {
                 'value': value,
                 'tags': tags,
-                'cached_at': datetime.utcnow().isoformat(),
+                'cached_at': datetime.now(timezone.utc).isoformat(),
                 'ttl': ttl
             }
             

--- a/server/tasks/background_tasks.py
+++ b/server/tasks/background_tasks.py
@@ -3,7 +3,7 @@ from models import User, WatchlistItem, Alert, Prediction
 from server.ml.data_fetcher import DataFetcher
 from server.ml.ml_models import MLModelManager
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 import os
 
 logger = logging.getLogger(__name__)
@@ -117,7 +117,7 @@ def check_price_alerts():
                     
                     if triggered:
                         # Mark as triggered
-                        alert.triggered_at = datetime.utcnow()
+                        alert.triggered_at = datetime.now(timezone.utc)
                         alert.is_active = False
                         
                         logger.info(f"Alert triggered for {alert.symbol}: {current_price} vs {alert.threshold}")
@@ -139,7 +139,7 @@ def cleanup_old_predictions():
     with app.app_context():
         try:
             # Delete predictions older than 30 days
-            cutoff_date = datetime.utcnow() - timedelta(days=30)
+            cutoff_date = datetime.now(timezone.utc) - timedelta(days=30)
             old_predictions = Prediction.query.filter(Prediction.created_at < cutoff_date).all()
             
             for pred in old_predictions:
@@ -156,7 +156,7 @@ def system_health_check():
     with app.app_context():
         try:
             health_status = {
-                'timestamp': datetime.utcnow().isoformat(),
+                'timestamp': datetime.now(timezone.utc).isoformat(),
                 'database': 'OK',
                 'api_connectivity': 'OK',
                 'model_status': 'OK',

--- a/server/utils/services/backtesting.py
+++ b/server/utils/services/backtesting.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 import yfinance as yf
 from server.utils.services.data_fetcher import DataFetcher
 from server.ml.ml_models import MLModelManager
@@ -59,7 +59,7 @@ class BacktestingEngine:
                 'trades': trades,
                 'portfolio_values': portfolio_values,
                 'benchmark': self._calculate_benchmark(data, initial_capital),
-                'timestamp': datetime.utcnow().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             }
             
             return results

--- a/server/utils/services/notification_service.py
+++ b/server/utils/services/notification_service.py
@@ -1,7 +1,7 @@
 import json
 import os
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from flask_mail import Message
 from app import mail, socketio
 import smtplib
@@ -35,7 +35,7 @@ class NotificationService:
             with open(self.alerts_file, 'r') as f:
                 alerts = json.load(f)
             
-            alert_id = f"{user_id}_{ticker}_{alert_type}_{datetime.utcnow().timestamp()}"
+            alert_id = f"{user_id}_{ticker}_{alert_type}_{datetime.now(timezone.utc).timestamp()}"
             
             alert_data = {
                 'id': alert_id,
@@ -45,7 +45,7 @@ class NotificationService:
                 'target_value': target_value,
                 'email': email,
                 'is_active': True,
-                'created_at': datetime.utcnow().isoformat(),
+                'created_at': datetime.now(timezone.utc).isoformat(),
                 'triggered_at': None,
                 'trigger_count': 0
             }
@@ -124,7 +124,7 @@ class NotificationService:
             # Update alerts file
             if triggered_alerts:
                 for alert_id in triggered_alerts:
-                    alerts[alert_id]['triggered_at'] = datetime.utcnow().isoformat()
+                    alerts[alert_id]['triggered_at'] = datetime.now(timezone.utc).isoformat()
                     alerts[alert_id]['trigger_count'] += 1
                 
                 with open(self.alerts_file, 'w') as f:
@@ -198,7 +198,7 @@ class NotificationService:
                 'message': message,
                 'current_price': float(current_price),
                 'target_value': target_value,
-                'timestamp': datetime.utcnow().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             })
             
             # Send email if provided
@@ -225,7 +225,7 @@ FullStock AI Price Alert
 
 {message}
 
-Time: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')}
+Time: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}
 
 This is an automated alert from FullStock AI vNext Ultimate.
 
@@ -249,7 +249,7 @@ The FullStock AI Team
             log_entry = {
                 'alert_id': alert_id,
                 'message': message,
-                'timestamp': datetime.utcnow().isoformat(),
+                'timestamp': datetime.now(timezone.utc).isoformat(),
                 'type': 'price_alert'
             }
             
@@ -273,7 +273,7 @@ The FullStock AI Team
                 'title': title,
                 'message': message,
                 'type': notification_type,
-                'timestamp': datetime.utcnow().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             })
             
             # Log system notification
@@ -292,7 +292,7 @@ The FullStock AI Team
             total_notifications = len(log_entries)
             
             # Last 24 hours
-            yesterday = datetime.utcnow() - timedelta(hours=24)
+            yesterday = datetime.now(timezone.utc) - timedelta(hours=24)
             recent_notifications = [
                 entry for entry in log_entries 
                 if datetime.fromisoformat(entry['timestamp']) > yesterday

--- a/server/utils/services/portfolio_tracker.py
+++ b/server/utils/services/portfolio_tracker.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import numpy as np
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from typing import Dict, List, Any, Optional
 import logging
 from app import db
@@ -144,7 +144,7 @@ class PortfolioTracker:
                 total_quantity = existing_position.quantity + quantity
                 existing_position.purchase_price = total_cost / total_quantity
                 existing_position.quantity = total_quantity
-                existing_position.purchase_date = datetime.utcnow()
+                existing_position.purchase_date = datetime.now(timezone.utc)
             else:
                 # Create new position
                 new_position = Portfolio(
@@ -153,7 +153,7 @@ class PortfolioTracker:
                     quantity=quantity,
                     purchase_price=purchase_price,
                     asset_type=asset_type,
-                    purchase_date=datetime.utcnow()
+                    purchase_date=datetime.now(timezone.utc)
                 )
                 db.session.add(new_position)
             

--- a/server/utils/strategic/curiosity_engine.py
+++ b/server/utils/strategic/curiosity_engine.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from sklearn.ensemble import IsolationForest
 from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler
@@ -69,7 +69,7 @@ class CuriosityEngine:
             
             return {
                 'ticker': ticker,
-                'timestamp': datetime.utcnow().isoformat(),
+                'timestamp': datetime.now(timezone.utc).isoformat(),
                 'curiosity_score': float(curiosity_score),
                 'curiosity_level': curiosity_level,
                 'anomaly_detection': {

--- a/server/utils/strategic/oracle_dreams.py
+++ b/server/utils/strategic/oracle_dreams.py
@@ -1,7 +1,7 @@
 import json
 import random
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 import os
 from server.utils.services.data_fetcher import DataFetcher
 import numpy as np
@@ -70,8 +70,8 @@ class OracleDreams:
             
             # Create dream record
             dream = {
-                'timestamp': datetime.utcnow().isoformat(),
-                'dream_id': f"dream_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}",
+                'timestamp': datetime.now(timezone.utc).isoformat(),
+                'dream_id': f"dream_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}",
                 'emotional_state': emotional_state,
                 'market_consciousness': market_analysis,
                 'mystical_narrative': narrative,
@@ -90,7 +90,7 @@ class OracleDreams:
             
         except Exception as e:
             logging.error(f"Error generating Oracle dream: {str(e)}")
-            return {'error': 'Oracle connection disrupted', 'timestamp': datetime.utcnow().isoformat()}
+            return {'error': 'Oracle connection disrupted', 'timestamp': datetime.now(timezone.utc).isoformat()}
     
     def _analyze_market_consciousness(self):
         """Analyze collective market consciousness through major indices"""


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.utcnow()` calls with timezone-aware `datetime.now(timezone.utc)`
- document UTC requirement and add `TZ` to `.env.example`
- add minimal project README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689900aedd4c832abb79fe0814c61624