### PR TITLE
fix: guard live updates function

### DIFF
--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -177,7 +177,9 @@ async function analyzeStock(ticker) {
         
         // Update UI with real data
         updatePredictionDisplay(data);
-        updateLiveUpdates(`📊 Analysis complete for ${ticker}`);
+        if (typeof window.updateLiveUpdates === 'function') {
+            window.updateLiveUpdates(`📊 Analysis complete for ${ticker}`);
+        }
         
         // Load chart data
         await loadChartData(ticker);
@@ -189,7 +191,9 @@ async function analyzeStock(ticker) {
     } catch (error) {
         console.error('Analysis error:', error);
         showError(`Failed to analyze ${ticker}: ${error.message}`);
-        updateLiveUpdates(`❌ Error analyzing ${ticker}: ${error.message}`);
+        if (typeof window.updateLiveUpdates === 'function') {
+            window.updateLiveUpdates(`❌ Error analyzing ${ticker}: ${error.message}`);
+        }
     } finally {
         console.log('Analysis completed, hiding loading state...');
         // Force hide loading immediately
@@ -484,3 +488,4 @@ document.addEventListener('DOMContentLoaded', setupMobileHandlers);
 // Export functions for global access
 window.analyzeStock = analyzeStock;
 window.initializeDashboard = initializeDashboard;
+window.updateLiveUpdates = updateLiveUpdates;

--- a/frontend/js/sockets.js
+++ b/frontend/js/sockets.js
@@ -39,8 +39,8 @@ function connect(url) {
         try {
             const data = JSON.parse(event.data);
             console.log('WebSocket message received', data);
-            if (data.ticker && typeof updateLiveUpdates === 'function') {
-                updateLiveUpdates(`📈 ${data.ticker} update`);
+            if (data.ticker && typeof window.updateLiveUpdates === 'function') {
+                window.updateLiveUpdates(`📈 ${data.ticker} update`);
             }
             hideWsWarning();
         } catch (err) {


### PR DESCRIPTION
## Summary
- ensure dashboard's analyze function checks for `updateLiveUpdates` before use
- expose `updateLiveUpdates` globally and update sockets to use it

## Testing
- `pytest` *(fails: KeyboardInterrupt during tests/test_ws.py after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_689909a52a28832ab6e855c93569c894